### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -11,8 +11,8 @@ const localstore = {};
 function setKeyToContent(formId, key) {
   localstore[formId] = key;
   localstore["currentId"] = formId;
-  document.getElementById("formId").innerHTML = formId;
-  document.getElementById("key").innerHTML = key || "No key found";
+  document.getElementById("formId").textContent = formId;
+  document.getElementById("key").textContent = key || "No key found";
 }
 
 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -80,7 +80,7 @@ function handleInsertKey() {
 
 function handleCopyKey() {
   const valueToCopy = document.getElementById("key").innerText;
-  document.getElementById("key").innerHTML = "Copied!";
+  document.getElementById("key").textContent = "Copied!";
   navigator.clipboard.writeText(valueToCopy);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/formsg-keys/security/code-scanning/1](https://github.com/opengovsg/formsg-keys/security/code-scanning/1)

To fix the problem, we need to ensure that the `formId` and `key` values are properly escaped before being inserted into the DOM. This can be done by using `textContent` instead of `innerHTML`, which will treat the values as plain text rather than HTML.

- Replace `innerHTML` with `textContent` for the `formId` and `key` elements.
- Ensure that any other instances of `innerHTML` in the provided code are also replaced with `textContent` if they are handling untrusted data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
